### PR TITLE
Fix #5 - Error: Cannot find module 'reactify'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
                     debug: true,
                     extensions: ['.js'],
                     transform: [
-                        ['reactify', {
+                        ['babelify', {
                             'es6': true
                         }]
                     ]
@@ -52,9 +52,9 @@ module.exports = function (grunt) {
                     debug: true,
                     extensions: ['.js'],
                     transform: [
-                        ['reactify', {
+                        ['babelify', {
                             'es6': true
-                        }] 
+                        }]
                     ]
                 }
             }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "grunt-watchify": "^0.1.0",
     "jscs": "^1.13.1",
     "react": ">=0.13.0",
-    "react-tools": "^0.13.3",
-    "reactify": "^0.17.1"
+    "babelify": "^6.1.3",
+    "babel": "^5.8.21"
   },
   "dependencies": {
     "extend": "^2.0.1",
@@ -38,7 +38,7 @@
   },
   "browserify": {
         "transform": [
-            "reactify"
+            "babelify"
         ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
     }
   ],
   "devDependencies": {
+    "babel": "^5.8.21",
+    "babelify": "^6.1.3",
     "browserify": "^9.0.3",
     "browserify-shim": "^3.8.3",
     "envify": "^3.2.0",
+    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "grunt": "^0.4.5",
     "grunt-bower-task": "^0.4.0",
     "grunt-browserify": "^3.8.0",
@@ -26,9 +29,7 @@
     "grunt-react": "^0.12.2",
     "grunt-watchify": "^0.1.0",
     "jscs": "^1.13.1",
-    "react": ">=0.13.0",
-    "babelify": "^6.1.3",
-    "babel": "^5.8.21"
+    "react": ">=0.13.0"
   },
   "dependencies": {
     "extend": "^2.0.1",
@@ -37,9 +38,9 @@
     "typeahead.js": "^0.11.1"
   },
   "browserify": {
-        "transform": [
-            "babelify"
-        ]
+    "transform": [
+      "babelify"
+    ]
   },
   "scripts": {
     "test": "grunt build",


### PR DESCRIPTION
- react-tools and reactify have been deprecated in
  favor of babel.
- See https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html
- `reactify` has been replaced by the `babelify` browserify transform.
